### PR TITLE
Fixes for Python 3.10

### DIFF
--- a/riak/client/__init__.py
+++ b/riak/client/__init__.py
@@ -341,7 +341,7 @@ class RiakClient(RiakMapReduceChain, RiakClientOperations):
     def _create_node(self, n):
         if isinstance(n, RiakNode):
             return n
-        elif isinstance(n, tuple) and len(n) is 3:
+        elif isinstance(n, tuple) and len(n) == 3:
             host, http_port, pb_port = n
             return RiakNode(host=host,
                             http_port=http_port,
@@ -382,7 +382,7 @@ class RiakClient(RiakMapReduceChain, RiakClientOperations):
 
         good = [n for n in nodes if _error_rate(n) < 0.1]
 
-        if len(good) is 0:
+        if len(good) == 0:
             # Fall back to a minimally broken node
             return min(nodes, key=_error_rate)
         else:

--- a/riak/client/index_page.py
+++ b/riak/client/index_page.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import namedtuple, Sequence
+from collections import namedtuple
+from collections.abc import Sequence
 
 
 CONTINUATION = namedtuple('Continuation', ['c'])

--- a/riak/datatypes/map.py
+++ b/riak/datatypes/map.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import Mapping
+from collections.abc import Mapping
 from riak.util import lazy_property
 from .datatype import Datatype
 from riak.datatypes import TYPES

--- a/riak/datatypes/register.py
+++ b/riak/datatypes/register.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import Sized
+from collections.abc import Sized
 from riak.datatypes.datatype import Datatype
 from six import string_types
 from riak.datatypes import TYPES

--- a/riak/datatypes/set.py
+++ b/riak/datatypes/set.py
@@ -21,7 +21,7 @@ from riak.datatypes import TYPES
 __all__ = ['Set']
 
 
-class Set(collections.Set, Datatype):
+class Set(collections.abc.Set, Datatype):
     """A convergent datatype representing a Set with observed-remove
     semantics. Currently strings are the only supported value type.
     Example::
@@ -116,7 +116,7 @@ class Set(collections.Set, Datatype):
         return frozenset(new_value)
 
     def _check_type(self, new_value):
-        if not isinstance(new_value, collections.Iterable):
+        if not isinstance(new_value, collections.abc.Iterable):
             return False
         for element in new_value:
             if not isinstance(element, string_types):

--- a/riak/mapreduce.py
+++ b/riak/mapreduce.py
@@ -16,7 +16,8 @@
 # limitations under the License.
 
 from __future__ import print_function
-from collections import Iterable, namedtuple
+from collections import namedtuple
+from collections.abc import Iterable
 from six import string_types, PY2
 
 import riak
@@ -358,7 +359,7 @@ class RiakMapReduce(object):
         num_phases = len(self._phases)
 
         # If there are no phases, return the keys as links
-        if num_phases is 0:
+        if num_phases == 0:
             link_results_flag = True
         else:
             link_results_flag = False

--- a/riak/util.py
+++ b/riak/util.py
@@ -18,7 +18,7 @@ import datetime
 import sys
 import warnings
 
-from collections import Mapping
+from collections.abc import Mapping
 from six import string_types, PY2
 
 epoch = datetime.datetime.utcfromtimestamp(0)


### PR DESCRIPTION
Using e.g. `collections.Mapping` instead of `collections.abc.Mapping` has been deprecated since Python 3.3.